### PR TITLE
Fix registration redirect to dashboard

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -15,8 +15,9 @@ def register():
         user.set_password(password)
         db.session.add(user)
         db.session.commit()
+        login_user(user)
         flash('Регистрация успешна')
-        return redirect(url_for('auth.login'))
+        return redirect(url_for('dashboard.index'))
     return render_template('register.html')
 
 @auth_bp.route('/login', methods=['GET', 'POST'])


### PR DESCRIPTION
## Summary
- log new users in automatically when registering
- redirect registered users to their dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6846de1effa0832c918967092666798c